### PR TITLE
fix: downgrade minimum Ruby version support from 3.3.x to 3.2.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         # Only tested on non-EOL Ruby versions
-        ruby: ["3.3", "3.4", "4.0"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
         operating-system: [ubuntu-latest]
         experimental: [No]
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,4 +24,4 @@ Metrics/BlockLength:
     - "*.gemspec"
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.2

--- a/yard_example_test.gemspec
+++ b/yard_example_test.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.3.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.add_dependency 'minitest', '~> 6.0'
   spec.add_dependency 'yard', '~> 0.9'


### PR DESCRIPTION
Downgrades the minimum supported Ruby version from 3.3.x to 3.2.x across the project.

## Changes

- **`yard_example_test.gemspec`**: Change `required_ruby_version` from `>= 3.3.0` to `>= 3.2.0`
- **`.github/workflows/continuous-integration.yml`**: Add Ruby `3.2` to the CI test matrix
- **`.rubocop.yml`**: Set `TargetRubyVersion` from `3.3` to `3.2`