### PR TITLE
build(dependencies): update dependencies for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}


### PR DESCRIPTION
Update GitHub Actions workflow dependencies to the latest major versions.

## Changes

- `actions/checkout`: `@v4` → `@v6` (latest: v6.0.2)
- `googleapis/release-please-action`: `@v4` → `@v5` (latest: v5.0.0)

## Actions already at latest major version

- `actions/checkout@v6` — latest is still v6 (latest: v6.0.2)
- `actions/setup-node@v6` — latest is still v6 (latest: v6.4.0)
- `ruby/setup-ruby@v1` — latest is still v1 (latest: v1.305.0)
- `rubygems/release-gem@v1` — latest is still v1 (latest: v1.2.0)
- `wagoid/commitlint-github-action@v6` — latest is still v6 (latest: v6.2.1)