### PR TITLE
fix: handle empty example text

### DIFF
--- a/features/yard_example_test.feature
+++ b/features/yard_example_test.feature
@@ -280,6 +280,26 @@ Feature: yard test-examples
     When I run `bundle exec yard test-examples`
     Then the output should contain "1 runs, 0 assertions, 0 failures, 0 errors, 0 skips"
 
+  Scenario: runs titled @example tags without a body
+    Given a file named "example_test_helper.rb" with:
+      """
+      require 'app/app'
+      """
+    And a file named "app/app.rb" with:
+      """
+      # @example sums two numbers
+      def sum(one, two)
+        one + two
+      end
+      """
+    When I run `bundle exec yard test-examples`
+    Then the output should contain "1 runs, 0 assertions, 0 failures, 0 errors, 0 skips"
+
+  Scenario: normalizes nil example text as no lines
+    When I run `bundle exec ruby -e "require 'yard_example_test'; command = YARD::CLI::TestExamples.new; p command.send(:normalize_example_lines, nil)"`
+    Then the output should contain "[]"
+    And the exit status should be 0
+
   Scenario: handles `# =>` return comment
     Given a file named "example_test_helper.rb" with:
       """

--- a/lib/yard/cli/test_examples.rb
+++ b/lib/yard/cli/test_examples.rb
@@ -261,15 +261,19 @@ module YARD
       # 3. Splits on newlines, strips leading and trailing whitespace from
       #    each line, and discards any blank lines.
       #
+      # If +text+ is +nil+ or blank, returns an empty array.
+      #
       # The resulting array is consumed by {#extract_expectations} to identify
       # code lines and their corresponding +#=>+ assertion lines.
       #
-      # @param text [String] the raw body text of a +@example+ tag
+      # @param text [String, nil] the raw body text of a +@example+ tag
       #
       # @return [Array<String>] the normalized, non-empty lines of the example;
       #   +#=>+ lines are always separate entries, never inline with code
       #
       def normalize_example_lines(text)
+        return [] if text.nil? || text.strip.empty?
+
         text = text.gsub('# =>', '#=>')
         text = text.gsub('#=>', "\n#=>")
         text.split("\n").map(&:strip).reject(&:empty?)


### PR DESCRIPTION
## Summary
- Return an empty line list when an @example body is nil or blank
- Add Cucumber coverage for titled empty examples and nil text normalization

Closes #15

## Verification
- PATH="/opt/homebrew/opt/ruby/bin:$PATH" bundle exec cucumber features/yard_example_test.feature:283:298
- git diff --check
- PATH="/opt/homebrew/opt/ruby/bin:$PATH" bundle exec rake

## AI disclosure
This contribution was prepared with AI assistance and manually reviewed before submission.